### PR TITLE
Invalid-token-error

### DIFF
--- a/lib/convertkit_v4/errors.rb
+++ b/lib/convertkit_v4/errors.rb
@@ -2,6 +2,7 @@ module ConvertkitV4
   class Error < StandardError; end
 
   class AuthorizationError < Error; end
+  class ExpiredTokenError < Error; end
   class ConnectionError < Error; end
   class NotFoundError < Error; end
   class ServerError < Error; end

--- a/lib/convertkit_v4/version.rb
+++ b/lib/convertkit_v4/version.rb
@@ -1,3 +1,3 @@
 module ConvertkitV4
-  VERSION = "1.0.13"
+  VERSION = "1.0.14"
 end


### PR DESCRIPTION
When a token has expired the response is a 401 and there are more details in the response header WWW-Authenticate. It will have an error of “invalid_token” and error_description will be “The access token expired”. When a token has been revoked, the response is the same, however the error_description will be “The access token was revoked”.