### PR TITLE
Subscriber-stats-endpoint

### DIFF
--- a/lib/convertkit_v4/client/subscribers.rb
+++ b/lib/convertkit_v4/client/subscribers.rb
@@ -43,6 +43,29 @@ module ConvertkitV4
       def subscriber_tags(subscriber_id)
         connection.get("subscribers/#{subscriber_id}/tags").body["tags"]
       end
+
+      # returns an hash with the following keys:
+      # {
+      #   "subscriber": {
+      #     "id": 3436990966,
+      #     "stats": {
+      #       "sent": 2,
+      #       "opened": 2,
+      #       "clicked": 2,
+      #       "bounced": 0,
+      #       "open_rate": 1,
+      #       "click_rate": 1,
+      #       "last_sent": "2025-06-25 16:44:37.000",
+      #       "last_opened": "2025-06-25 16:45:36.000",
+      #       "last_clicked": "2025-06-25 16:45:42.000",
+      #       "sent_since_last_open": 0,
+      #       "sent_since_last_click": 0
+      #     }
+      #   }
+      # }
+      def subscriber_stats(subscriber_id)
+        connection.get("subscribers/#{subscriber_id}/stats").body["subscriber"]
+      end
     end
   end
 end

--- a/lib/convertkit_v4/version.rb
+++ b/lib/convertkit_v4/version.rb
@@ -1,3 +1,3 @@
 module ConvertkitV4
-  VERSION = "1.0.20"
+  VERSION = "1.1.0"
 end

--- a/spec/convertkit_v4/client/subscribers_spec.rb
+++ b/spec/convertkit_v4/client/subscribers_spec.rb
@@ -81,6 +81,14 @@ module ConvertkitV4
           }.by(-1)
         end
       end
+
+      describe "#subscriber_stats" do
+        it "returns the stats for a subscriber" do
+          subscriber_id = ENV['SUBSCRIBER_ID']
+          r = @client.subscriber_stats(subscriber_id)
+          expect(r.success?).to be_truthy
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Added support for `/stats` endpoint which returns subscribers' engagement stats.

https://sparkloophq.slack.com/archives/C0180DX6X5Z/p1752084760221219